### PR TITLE
Add environment validation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,5 +10,17 @@ Beyond Linux from Scratch
 
 Gaming on Linux from Scratch
 
-
 All in one application.
+
+## Environment Validation
+
+A helper script `scripts/validate_environment.sh` checks that your system has all
+required tools and enough resources before starting a build.
+
+Run it with:
+
+```bash
+./scripts/validate_environment.sh        # run both checks
+./scripts/validate_environment.sh validate  # only tool check
+./scripts/validate_environment.sh health    # only environment health check
+```

--- a/scripts/validate_environment.sh
+++ b/scripts/validate_environment.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+# Auto-LFS-Builder Environment Validation Script
+
+# Validate required tools are present
+validate_environment() {
+    local required_tools=(
+        "bash" "gcc" "g++" "make" "bison" "flex" "gawk"
+        "texinfo" "patch" "tar" "gzip" "bzip2" "xz"
+        "wget" "curl" "git" "python3" "xmllint" "pandoc"
+    )
+
+    for tool in "${required_tools[@]}"; do
+        if ! command -v "$tool" &> /dev/null; then
+            echo "ERROR: Required tool '$tool' not found" >&2
+            return 1
+        fi
+    done
+
+    echo "All required tools are available"
+    return 0
+}
+
+# Check environment configuration and available resources
+check_environment_health() {
+    # Check disk space
+    local available_space=$(df . | awk 'NR==2 {print $4}')
+    local required_space=52428800  # 50GB in KB
+
+    if [ "$available_space" -lt "$required_space" ]; then
+        echo "WARNING: Insufficient disk space" >&2
+    fi
+
+    # Check memory
+    local available_memory=$(free -m | awk 'NR==2{print $7}')
+    if [ "$available_memory" -lt 4096 ]; then
+        echo "WARNING: Less than 4GB available memory" >&2
+    fi
+
+    # Check documentation directory
+    if [ ! -d "$DOCS_ROOT" ]; then
+        echo "ERROR: Documentation directory not found: $DOCS_ROOT" >&2
+        return 1
+    fi
+
+    echo "Environment health check passed"
+    return 0
+}
+
+usage() {
+    echo "Usage: $0 [validate|health|all]" >&2
+    echo "  validate   Run validate_environment" >&2
+    echo "  health     Run check_environment_health" >&2
+    echo "  all (default) Run both checks" >&2
+}
+
+main() {
+    local action=${1:-all}
+    case "$action" in
+        validate)
+            validate_environment
+            ;;
+        health)
+            check_environment_health
+            ;;
+        all)
+            validate_environment && check_environment_health
+            ;;
+        *)
+            usage
+            exit 1
+            ;;
+    esac
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- implement validation helpers in `scripts/validate_environment.sh`
- document new script usage in README

## Testing
- `bash -n scripts/validate_environment.sh`
- `./scripts/validate_environment.sh validate` *(fails: `ERROR: Required tool 'flex' not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68710aa758948332b9992f154a2905ed