### PR TITLE
Add MIT license file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,25 @@
+Auto-LFS-Builder
+
+MIT License
+
+This project is licensed under the MIT License. The text below mirrors the license found in docs/jhalfs/LICENSE so users clearly know the terms.
+
+Copyright (C) 2005-2019, jhalfs team
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -12,3 +12,7 @@ Gaming on Linux from Scratch
 
 
 All in one application.
+
+## License
+
+Auto-LFS-Builder is released under the [MIT License](LICENSE). The license text matches the one bundled with `docs/jhalfs/LICENSE` so users can easily review the project terms.


### PR DESCRIPTION
## Summary
- add MIT license file with text matching docs/jhalfs/LICENSE
- mention the MIT license in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68710aa285ec8332a08cd0f891c1f987