### PR TITLE
Add desktop GNOME profile

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,6 +90,7 @@ auto-lfs-builder/
 │   └── validation_suite.sh        # Comprehensive testing
 ├── config/                        # Build configurations
 │   ├── build_profiles/            # Target system configurations
+│   │   └── desktop_gnome.conf    # Default GNOME profile
 │   ├── package_versions.conf      # Version specifications
 │   └── hardware_support.conf      # Hardware-specific settings
 └── logs/                          # Build logs and debugging
@@ -97,6 +98,7 @@ auto-lfs-builder/
     ├── build_logs/                # Construction logs
     └── validation_logs/           # Testing and verification logs
 ```
+The `config/build_profiles/desktop_gnome.conf` file provides default build options for GNOME and networking.
 
 ## AI Agent Instructions for Documentation Processing
 

--- a/README.md
+++ b/README.md
@@ -12,3 +12,5 @@ Gaming on Linux from Scratch
 
 
 All in one application.
+
+Configuration defaults are stored in `config/build_profiles/desktop_gnome.conf`.

--- a/config/build_profiles/desktop_gnome.conf
+++ b/config/build_profiles/desktop_gnome.conf
@@ -1,0 +1,8 @@
+# Auto-LFS-Builder GNOME desktop profile
+# This configuration enables the GNOME desktop and networking
+# for an x86_64 system.
+
+ENABLE_GNOME=true
+ENABLE_NETWORKING=true
+TARGET_ARCH=x86_64
+BUILD_PROFILE=desktop_gnome


### PR DESCRIPTION
## Summary
- add config/build_profiles/desktop_gnome.conf with default settings
- mention the new profile in README and AGENTS documentation

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68710a9acf188332b9ab8ed534b4577a