### PR TITLE
Add common utility scripts

### DIFF
--- a/src/common/error_handling.sh
+++ b/src/common/error_handling.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Common error handling
+
+handle_error() {
+    local message="$1"
+    log_error "$message"
+    exit 1
+}
+

--- a/src/common/logging.sh
+++ b/src/common/logging.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Common logging functions
+
+_timestamp() {
+    date '+%Y-%m-%d %H:%M:%S'
+}
+
+log_info() {
+    echo "[INFO $( _timestamp )] $*"
+}
+
+log_success() {
+    echo "[SUCCESS $( _timestamp )] $*"
+}
+
+log_error() {
+    echo "[ERROR $( _timestamp )] $*" >&2
+}
+
+log_warn() {
+    echo "[WARN $( _timestamp )] $*"
+}

--- a/src/common/package_management.sh
+++ b/src/common/package_management.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Common package management functions
+
+PACKAGES_DIR=${PACKAGES_DIR:-packages}
+BUILD_DIR=${BUILD_DIR:-build}
+
+# Download a package with checksum verification
+# Usage: download_package name url checksum
+download_package() {
+    local name="$1"
+    local url="$2"
+    local checksum="$3"
+
+    mkdir -p "$PACKAGES_DIR"
+    log_info "Downloading $name"
+    wget -c "$url" -O "$PACKAGES_DIR/$name" || handle_error "Failed to download $name"
+    verify_checksum "$PACKAGES_DIR/$name" "$checksum" || handle_error "Checksum mismatch for $name"
+}
+
+# Verify SHA256 checksum
+# Usage: verify_checksum file expected_checksum
+verify_checksum() {
+    local file="$1"
+    local expected="$2"
+
+    echo "$expected  $file" | sha256sum -c - >/dev/null 2>&1
+}
+
+# Extract a package archive
+# Usage: extract_package name
+extract_package() {
+    local name="$1"
+
+    mkdir -p "$BUILD_DIR"
+    log_info "Extracting $name"
+    tar -xf "$PACKAGES_DIR/$name" -C "$BUILD_DIR" || handle_error "Failed to extract $name"
+}


### PR DESCRIPTION
## Summary
- add `src/common/` directory for shared functions
- implement logging functions
- implement basic error handler
- add package management helpers

## Testing
- `bash -n src/common/logging.sh src/common/error_handling.sh src/common/package_management.sh`
- `bash -n src/builders/*.sh src/installers/*.sh src/validators/*.sh`
- `python3 -m py_compile src/parsers/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68711b8347848332a731c82dec98c102