### PR TITLE
Add desktop GNOME build profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,15 @@ Gaming on Linux from Scratch
 
 All in one application.
 See [setup.md](setup.md) for environment configuration details.
+
+## Getting Started
+
+Use the desktop GNOME build profile as a starting point:
+
+```bash
+source config/build_profiles/desktop_gnome.conf
+./generated/complete_build.sh
+```
+
+This loads environment variables such as `ENABLE_GNOME`, `ENABLE_NETWORKING`, and
+`PARALLEL_JOBS` so the build runs with a full GNOME desktop.

--- a/config/build_profiles/desktop_gnome.conf
+++ b/config/build_profiles/desktop_gnome.conf
@@ -1,0 +1,14 @@
+# Desktop GNOME build profile
+# Derived from SETUP.md Production Build Environment
+
+export LFS="/mnt/lfs"
+export BUILD_PROFILE="desktop_gnome"
+export PARALLEL_JOBS="$(nproc)"
+export PARSING_LOG_LEVEL="INFO"
+export VALIDATION_MODE="strict"
+export ENABLE_GNOME="true"
+export ENABLE_NETWORKING="true"
+export ENABLE_MULTIMEDIA="true"
+export SECURITY_HARDENING="true"
+export VERIFY_PACKAGES="true"
+export CHECKSUM_VALIDATION="all"


### PR DESCRIPTION
## Summary
- add `config/build_profiles/desktop_gnome.conf`
- show how to use the GNOME profile in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68711b9a5c5883328a9a88575ee4a2c5