### PR TITLE
Add common utility scripts

### DIFF
--- a/src/common/error_handling.sh
+++ b/src/common/error_handling.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Error handling utilities
+
+handle_error() {
+    local msg="$1"
+    log_error "$msg"
+    exit 1
+}
+
+check_binary_exists() {
+    local bin="$1"
+    local err_msg="$2"
+    command -v "$bin" >/dev/null 2>&1 || handle_error "$err_msg"
+}
+

--- a/src/common/logging.sh
+++ b/src/common/logging.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Logging utilities for Auto-LFS-Builder
+
+LOG_DIR="${LOG_DIR:-logs}"
+mkdir -p "$LOG_DIR"
+
+_timestamp() {
+    date '+%Y-%m-%d %H:%M:%S'
+}
+
+log_info() {
+    echo "[INFO  $(_timestamp)] $*"
+}
+
+log_success() {
+    echo "[OK    $(_timestamp)] $*"
+}
+
+log_warning() {
+    echo "[WARN  $(_timestamp)] $*" >&2
+}
+
+log_error() {
+    echo "[ERROR $(_timestamp)] $*" >&2
+}
+

--- a/src/common/package_management.sh
+++ b/src/common/package_management.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# Package management utilities
+
+PACKAGES_DIR="${PACKAGES_DIR:-packages}"
+BUILD_DIR="${BUILD_DIR:-build}"
+mkdir -p "$PACKAGES_DIR" "$BUILD_DIR"
+
+verify_checksum() {
+    local file="$1"
+    local checksum="$2"
+    echo "$checksum  $file" | sha256sum -c - || handle_error "Checksum verification failed for $file"
+}
+
+extract_package() {
+    local package="$1"
+    tar -xf "${PACKAGES_DIR}/${package}" -C "$BUILD_DIR" || handle_error "Failed to extract ${package}"
+}
+
+download_package() {
+    local package_name="$1"
+    local package_url="$2"
+    local checksum="$3"
+
+    log_info "Downloading $package_name"
+    wget -c "$package_url" -O "${PACKAGES_DIR}/${package_name}" || handle_error "Download failed for $package_name"
+    verify_checksum "${PACKAGES_DIR}/${package_name}" "$checksum"
+}
+
+build_package() {
+    local package_name="$1"
+    local build_function="$2"
+
+    log_info "Building $package_name"
+    extract_package "$package_name"
+    cd "${BUILD_DIR}/${package_name%.tar*}" || handle_error "Build directory missing for $package_name"
+    "$build_function" || handle_error "Build failed for $package_name"
+    cd - > /dev/null
+}
+


### PR DESCRIPTION
## Summary
- add `src/common/` utilities for logging, error handling, and package management
- implement `log_info`, `log_success`, `handle_error`, `download_package`, and other helper functions
- utilities match standards from `AGENTS.md`

## Testing
- `bash -n src/common/logging.sh src/common/error_handling.sh src/common/package_management.sh`
- `bash -n src/builders/*.sh src/installers/*.sh src/validators/*.sh`


------
https://chatgpt.com/codex/tasks/task_e_68711b8b8ff48332a96d94d6ed11eb61