### PR TITLE
Implement parser modules with CLI and tests

### DIFF
--- a/src/parsers/dependency_resolver.py
+++ b/src/parsers/dependency_resolver.py
@@ -1,20 +1,88 @@
-"""Build Dependency Resolver.
-Calculates build order for packages based on parsed documentation.
-"""
+"""Simple dependency resolution helpers."""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+from bs4 import BeautifulSoup
+
+DOCS_ROOT = Path(__file__).resolve().parents[2] / "docs"
+DEPENDENCY_XML = DOCS_ROOT / "lfs-git" / "appendices" / "dependencies.xml"
 
 
-def build_dependency_graph(packages):
-    """Create a dependency graph from given package list"""
-    # TODO: implement graph creation
-    return {}
+def build_dependency_graph(packages: list[str], dependency_file: str | Path = DEPENDENCY_XML) -> dict[str, list[str]]:
+    """Create a dependency graph from ``dependencies.xml`` for *packages*."""
+
+    dep_path = Path(dependency_file)
+    graph: dict[str, list[str]] = {pkg: [] for pkg in packages}
+    if not dep_path.exists():
+        return graph
+
+    with dep_path.open(encoding="utf-8") as fh:
+        soup = BeautifulSoup(fh, "xml")
+
+    for pkg in packages:
+        bridge = None
+        for b in soup.find_all("bridgehead"):
+            if b.get_text().strip().lower() == pkg.lower():
+                bridge = b
+                break
+
+        if not bridge:
+            continue
+
+        seglist = bridge.find_next("segmentedlist", id=re.compile(r".*-depends$"))
+        if not seglist:
+            continue
+
+        seg = seglist.find("seg")
+        if not seg:
+            continue
+
+        text = seg.get_text().replace(" and ", ", ")
+        deps = [d.strip().rstrip(".") for d in text.split(",") if d.strip() and d.strip().lower() != "none"]
+        graph[pkg] = deps
+
+    return graph
 
 
-def topological_sort(graph):
-    """Perform topological sort on dependency graph"""
-    # TODO: implement sorting algorithm
-    return []
+def topological_sort(graph: dict[str, list[str]]) -> list[str]:
+    """Perform a topological sort of *graph* returning the build order."""
+
+    order: list[str] = []
+    visited: dict[str, str] = {}
+
+    def visit(node: str) -> None:
+        state = visited.get(node)
+        if state == "visiting":
+            raise ValueError(f"circular dependency detected at {node}")
+        if state == "visited":
+            return
+        visited[node] = "visiting"
+        for dep in graph.get(node, []):
+            if dep in graph:
+                visit(dep)
+        visited[node] = "visited"
+        order.append(node)
+
+    for node in graph:
+        visit(node)
+
+    return order
+
+
+def _cli() -> None:
+    parser = argparse.ArgumentParser(description="Resolve package dependencies")
+    parser.add_argument("packages", nargs="+", help="Package names to resolve")
+    args = parser.parse_args()
+
+    graph = build_dependency_graph(args.packages)
+    order = topological_sort(graph)
+    for pkg in order:
+        print(pkg)
 
 
 if __name__ == "__main__":
-    # Placeholder for CLI usage
-    pass
+    _cli()

--- a/src/parsers/documentation_merger.py
+++ b/src/parsers/documentation_merger.py
@@ -1,17 +1,37 @@
-"""Documentation Merger.
-Combines LFS, BLFS, JHALFS, and GLFS documentation sources.
-"""
+"""Utilities for combining documentation sources."""
 
-def merge_sources(sources):
-    """Merge multiple documentation sources"""
-    # TODO: implement merging logic
-    return ""
+from __future__ import annotations
 
-def update_documentation():
-    """Fetch and update documentation repositories"""
-    # TODO: implement update routine
-    pass
+import argparse
+from pathlib import Path
+
+
+def merge_sources(sources: list[str | Path]) -> str:
+    """Return the concatenation of all files in *sources*."""
+
+    contents = []
+    for src in sources:
+        path = Path(src)
+        if not path.exists():
+            continue
+        contents.append(path.read_text(encoding="utf-8"))
+    return "\n".join(contents)
+
+
+def update_documentation() -> None:
+    """Placeholder routine for documentation updates."""
+
+    print("Updating documentation repositories ... (not implemented)")
+
+
+def _cli() -> None:
+    parser = argparse.ArgumentParser(description="Merge documentation files")
+    parser.add_argument("files", nargs="+", help="Documentation files to merge")
+    args = parser.parse_args()
+
+    merged = merge_sources(args.files)
+    print(merged)
+
 
 if __name__ == "__main__":
-    # Placeholder for CLI usage
-    pass
+    _cli()

--- a/src/parsers/lfs_parser.py
+++ b/src/parsers/lfs_parser.py
@@ -1,24 +1,97 @@
-"""LFS Documentation Parser.
-Parses LFS HTML/XML files to extract build commands and dependency information.
-"""
+"""Utilities for parsing LFS documentation files."""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
 
 from bs4 import BeautifulSoup
 
+DOCS_ROOT = Path(__file__).resolve().parents[2] / "docs"
+DEPENDENCY_XML = DOCS_ROOT / "lfs-git" / "appendices" / "dependencies.xml"
 
-def extract_build_commands(chapter_file):
-    """Extract build commands from LFS documentation"""
-    # TODO: implement actual parsing logic
-    commands = []
+
+def clean_command(text: str) -> str:
+    """Remove prompts and extraneous whitespace from a command string."""
+
+    lines = []
+    for line in text.strip().splitlines():
+        line = line.strip()
+        # remove common shell prompts
+        line = re.sub(r"^[#$]\s*", "", line)
+        lines.append(line)
+    return "\n".join(lines)
+
+
+def is_build_command(cmd: str) -> bool:
+    """Return ``True`` if *cmd* looks like an actual build command."""
+
+    return bool(cmd and not cmd.startswith("#"))
+
+
+def extract_build_commands(chapter_file: str | Path) -> list[str]:
+    """Extract build commands from an LFS chapter file."""
+
+    chapter_path = Path(chapter_file)
+    with chapter_path.open(encoding="utf-8") as fh:
+        soup = BeautifulSoup(fh, "html.parser")
+
+    build_blocks = soup.find_all("pre", class_="userinput")
+    build_blocks += soup.find_all("userinput")
+
+    commands: list[str] = []
+    for block in build_blocks:
+        cmd = clean_command(block.get_text())
+        if is_build_command(cmd):
+            commands.append(cmd)
+
     return commands
 
 
-def resolve_dependencies(package_name):
-    """Parse dependency information from documentation"""
-    # TODO: implement dependency resolution
-    deps = []
+def resolve_dependencies(package_name: str, dependency_file: str | Path = DEPENDENCY_XML) -> list[str]:
+    """Parse dependency information for *package_name* from ``dependencies.xml``."""
+
+    dep_path = Path(dependency_file)
+    if not dep_path.exists():
+        return []
+
+    with dep_path.open(encoding="utf-8") as fh:
+        soup = BeautifulSoup(fh, "xml")
+
+    bridge = None
+    for b in soup.find_all("bridgehead"):
+        if b.get_text().strip().lower() == package_name.lower():
+            bridge = b
+            break
+
+    if not bridge:
+        return []
+
+    seglist = bridge.find_next("segmentedlist", id=re.compile(r".*-depends$"))
+    if not seglist:
+        return []
+
+    seg = seglist.find("seg")
+    if not seg:
+        return []
+
+    text = seg.get_text()
+    text = text.replace(" and ", ", ")
+    deps = [d.strip().rstrip(".") for d in text.split(",") if d.strip() and d.strip().lower() != "none"]
+
     return deps
 
 
+def _cli() -> None:
+    parser = argparse.ArgumentParser(description="Extract build commands from an LFS chapter file")
+    parser.add_argument("chapter", help="Path to chapter XML/HTML file")
+    args = parser.parse_args()
+
+    commands = extract_build_commands(args.chapter)
+    for cmd in commands:
+        print(cmd)
+
+
 if __name__ == "__main__":
-    # Placeholder for CLI usage
-    pass
+    _cli()

--- a/src/parsers/package_analyzer.py
+++ b/src/parsers/package_analyzer.py
@@ -1,17 +1,62 @@
-"""Package Analyzer.
-Determines package requirements from documentation sources.
-"""
+"""Helpers for analyzing package build instructions."""
 
-def analyze_package(package_name):
-    """Analyze package build instructions"""
-    # TODO: implement analysis logic
-    return {}
+from __future__ import annotations
 
-def extract_requirements(package_name):
-    """Extract package requirements"""
-    # TODO: implement requirement extraction
-    return []
+import argparse
+import os
+from pathlib import Path
+
+from .lfs_parser import extract_build_commands, resolve_dependencies
+
+DOCS_ROOT = Path(__file__).resolve().parents[2] / "docs"
+
+
+def _find_package_file(package_name: str, root: Path = DOCS_ROOT) -> Path | None:
+    name_lower = package_name.lower()
+    for directory, _, files in os.walk(root):
+        for f in files:
+            if f.lower().startswith(name_lower) and f.endswith(".xml"):
+                return Path(directory) / f
+    return None
+
+
+def analyze_package(package_name: str) -> dict:
+    """Return build commands and dependencies for *package_name*."""
+
+    path = _find_package_file(package_name)
+    if not path:
+        return {}
+
+    commands = extract_build_commands(path)
+    deps = resolve_dependencies(package_name)
+    return {"name": package_name, "file": str(path), "commands": commands, "dependencies": deps}
+
+
+def extract_requirements(package_name: str) -> list[str]:
+    """Extract dependency requirements for *package_name*."""
+
+    return resolve_dependencies(package_name)
+
+
+def _cli() -> None:
+    parser = argparse.ArgumentParser(description="Analyze a package definition")
+    parser.add_argument("package", help="Package name")
+    args = parser.parse_args()
+
+    data = analyze_package(args.package)
+    if not data:
+        print("Package not found")
+        return
+
+    print(f"Package: {data['name']}")
+    print(f"File: {data['file']}")
+    print("Dependencies:")
+    for dep in data["dependencies"]:
+        print(f"  - {dep}")
+    print("Commands:")
+    for cmd in data["commands"]:
+        print(cmd)
+
 
 if __name__ == "__main__":
-    # Placeholder for CLI usage
-    pass
+    _cli()

--- a/tests/test_dependency_resolver.py
+++ b/tests/test_dependency_resolver.py
@@ -1,0 +1,12 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'src'))
+
+from parsers import dependency_resolver
+
+
+def test_topological_sort_simple():
+    graph = {'pkg1': ['pkg2'], 'pkg2': []}
+    order = dependency_resolver.topological_sort(graph)
+    assert order == ['pkg2', 'pkg1']

--- a/tests/test_lfs_parser.py
+++ b/tests/test_lfs_parser.py
@@ -1,0 +1,14 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'src'))
+
+from parsers import lfs_parser
+
+
+def test_extract_build_commands():
+    sample = Path('docs/lfs-git/chapter05/binutils-pass1.xml')
+    commands = lfs_parser.extract_build_commands(sample)
+    assert commands, 'No commands extracted'
+    joined = '\n'.join(commands)
+    assert 'make' in joined


### PR DESCRIPTION
## Summary
- flesh out parsing utilities for LFS docs
- implement dependency resolver logic
- add package analysis helpers
- create simple documentation merger
- add small unit tests

## Testing
- `python3 -m unittest discover -v tests` *(fails: ModuleNotFoundError: No module named 'bs4')*

------
https://chatgpt.com/codex/tasks/task_e_68711b8ce70083329f30a2b6800fc09e