### PR TITLE
Add common helper improvements

### DIFF
--- a/src/common/error_handling.sh
+++ b/src/common/error_handling.sh
@@ -7,9 +7,17 @@ handle_error() {
     exit 1
 }
 
-check_binary_exists() {
-    local bin="$1"
-    local err_msg="$2"
-    command -v "$bin" >/dev/null 2>&1 || handle_error "$err_msg"
+# Log script exit status
+on_exit() {
+    local status=$?
+    if [ $status -ne 0 ]; then
+        log_error "Script aborted with status $status"
+    else
+        log_success "Script completed successfully"
+    fi
 }
+
+# Trap unexpected errors and script exit
+trap 'handle_error "An error occurred on line $LINENO"' ERR
+trap on_exit EXIT
 

--- a/src/common/package_management.sh
+++ b/src/common/package_management.sh
@@ -5,6 +5,13 @@ PACKAGES_DIR="${PACKAGES_DIR:-packages}"
 BUILD_DIR="${BUILD_DIR:-build}"
 mkdir -p "$PACKAGES_DIR" "$BUILD_DIR"
 
+# Ensure required binaries are present
+check_binary_exists() {
+    local bin="$1"
+    local err_msg="$2"
+    command -v "$bin" >/dev/null 2>&1 || handle_error "$err_msg"
+}
+
 verify_checksum() {
     local file="$1"
     local checksum="$2"


### PR DESCRIPTION
## Summary
- refine error handling with traps
- centralize binary checks in package management helpers
- keep timestamped logging functions

## Testing
- `bash tests/run_tests.sh > /tmp/test.log 2>&1 && cat /tmp/test.log`

------
https://chatgpt.com/codex/tasks/task_e_68711b7b0bdc833291c7299d068948d6