### PR TITLE
Fix package analyzer execution

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,1 @@
+"""Auto-LFS-Builder package"""

--- a/src/parsers/__init__.py
+++ b/src/parsers/__init__.py
@@ -1,0 +1,1 @@
+"""Parsers package"""

--- a/src/parsers/regenerate_all_scripts.sh
+++ b/src/parsers/regenerate_all_scripts.sh
@@ -25,7 +25,8 @@ run_parsers() {
         || handle_error "Dependency resolution failed"
 
     log_info "Analyzing package requirements"
-    python3 src/parsers/package_analyzer.py > logs/parsing_logs/package_analyzer.log 2>&1 \
+    PYTHONPATH="src${PYTHONPATH:+:$PYTHONPATH}" \
+        python3 -m parsers.package_analyzer > logs/parsing_logs/package_analyzer.log 2>&1 \
         || handle_error "Package analysis failed"
 }
 


### PR DESCRIPTION
## Summary
- add package initializers so parser modules can be imported
- call package_analyzer via `python3 -m` in regenerate script

## Testing
- `pytest -q` *(fails: No module named 'bs4')*
- `./src/parsers/regenerate_all_scripts.sh` *(fails: documentation arguments missing)*

------
https://chatgpt.com/codex/tasks/task_e_68713db4f6148332b4588d2436176bb5