### PR TITLE
Add complete build script and CI update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,5 +12,12 @@ jobs:
       - uses: actions/checkout@v3
       - name: Run validation suite
         run: ENABLE_GNOME=false bash generated/validation_suite.sh
+      - name: Run complete build script
+        run: |
+          if [ -f generated/complete_build.sh ]; then
+            ENABLE_GNOME=false bash generated/complete_build.sh
+          else
+            echo "complete_build.sh not found, skipping"
+          fi
       - name: Run unit tests
         run: bash tests/run_tests.sh

--- a/generated/complete_build.sh
+++ b/generated/complete_build.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Complete Build: orchestrates full LFS, networking, GNOME, and BLFS build
+set -euo pipefail
+
+source src/common/logging.sh
+source src/common/error_handling.sh
+source src/common/package_management.sh
+
+main() {
+    log_info "Starting complete build process"
+    bash src/builders/lfs_builder.sh
+    bash src/builders/networking_builder.sh
+    bash src/builders/gnome_builder.sh
+    bash src/builders/blfs_builder.sh
+    log_success "Complete build finished successfully"
+}
+
+main "$@"
+


### PR DESCRIPTION
## Summary
- generate `complete_build.sh` orchestrating the main build steps
- run the new build script from the CI workflow when available

## Testing
- `ENABLE_GNOME=false bash generated/validation_suite.sh`
- `bash tests/run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68713db21fc48332af37851879f0a6bc