### PR TITLE
Add pytest execution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install requirements
+        run: |
+          python -m pip install --upgrade pip
+          pip install beautifulsoup4 lxml requests pytest
       - name: Run validation suite
         run: ENABLE_GNOME=false bash generated/validation_suite.sh
       - name: Run unit tests

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -10,4 +10,7 @@ if check_binary_exists nonexistent_binary "should fail"; then
     exit 1
 fi
 
+# run Python unit tests
+python -m pytest -q tests
+
 echo "All unit tests passed"


### PR DESCRIPTION
## Summary
- run Python unit tests from run_tests.sh using pytest
- install test requirements in CI workflow before running tests

## Testing
- `bash tests/run_tests.sh` *(fails: ModuleNotFoundError: No module named 'bs4')*

------
https://chatgpt.com/codex/tasks/task_e_68713db562a88332a872a0d4312ba66b