### PR TITLE
Update test imports for src package

### DIFF
--- a/tests/test_dependency_resolver.py
+++ b/tests/test_dependency_resolver.py
@@ -1,9 +1,9 @@
 import sys
 from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'src'))
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from parsers import dependency_resolver
+from src.parsers import dependency_resolver
 
 
 def test_topological_sort_simple():

--- a/tests/test_lfs_parser.py
+++ b/tests/test_lfs_parser.py
@@ -1,9 +1,9 @@
 import sys
 from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'src'))
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from parsers import lfs_parser
+from src.parsers import lfs_parser
 
 
 def test_extract_build_commands():


### PR DESCRIPTION
## Summary
- add empty `__init__.py` to make `src` a package
- update test imports to use package-style paths
- adjust `sys.path` usage in tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'bs4')*

------
https://chatgpt.com/codex/tasks/task_e_68713dc21e4c83328fbc40505d7abec0