### PR TITLE
Add MIT license header to scripts

### DIFF
--- a/generated/validation_suite.sh
+++ b/generated/validation_suite.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 The LFS Automation Team
+
 # Comprehensive validation suite for Auto-LFS-Builder
 set -euo pipefail
 

--- a/src/builders/blfs_builder.sh
+++ b/src/builders/blfs_builder.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 The LFS Automation Team
+
 # BLFS Builder: Install additional BLFS packages
 set -euo pipefail
 

--- a/src/builders/gnome_builder.sh
+++ b/src/builders/gnome_builder.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 The LFS Automation Team
+
 # GNOME Builder: Install GNOME desktop environment
 set -euo pipefail
 

--- a/src/builders/lfs_builder.sh
+++ b/src/builders/lfs_builder.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 The LFS Automation Team
+
 # LFS Builder: Core LFS build automation
 set -euo pipefail
 

--- a/src/builders/master_builder.sh
+++ b/src/builders/master_builder.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 The LFS Automation Team
+
 # Master Builder: Orchestrates complete system build
 set -euo pipefail
 

--- a/src/builders/networking_builder.sh
+++ b/src/builders/networking_builder.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 The LFS Automation Team
+
 # Networking Builder: Configure network stack
 set -euo pipefail
 

--- a/src/common/error_handling.sh
+++ b/src/common/error_handling.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 The LFS Automation Team
+
 # Error handling utilities
 
 handle_error() {

--- a/src/common/logging.sh
+++ b/src/common/logging.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 The LFS Automation Team
+
 # Logging utilities for Auto-LFS-Builder
 
 LOG_DIR="${LOG_DIR:-logs}"

--- a/src/common/package_management.sh
+++ b/src/common/package_management.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 The LFS Automation Team
+
 # Package management utilities
 
 PACKAGES_DIR="${PACKAGES_DIR:-packages}"

--- a/src/installers/bootstrap_installer.sh
+++ b/src/installers/bootstrap_installer.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 The LFS Automation Team
+
 # Bootstrap Installer: Hardware detection and installation
 set -euo pipefail
 

--- a/src/installers/iso_creator.sh
+++ b/src/installers/iso_creator.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 The LFS Automation Team
+
 # ISO Creator: Generate bootable ISO image
 set -euo pipefail
 

--- a/src/installers/partition_manager.sh
+++ b/src/installers/partition_manager.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 The LFS Automation Team
+
 # Partition Manager: Automatic disk partitioning
 set -euo pipefail
 

--- a/src/parsers/dependency_resolver.py
+++ b/src/parsers/dependency_resolver.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 The LFS Automation Team
+
 """Simple dependency resolution helpers."""
 
 from __future__ import annotations

--- a/src/parsers/documentation_merger.py
+++ b/src/parsers/documentation_merger.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 The LFS Automation Team
+
 """Utilities for combining documentation sources."""
 
 from __future__ import annotations

--- a/src/parsers/lfs_parser.py
+++ b/src/parsers/lfs_parser.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 The LFS Automation Team
+
 """Utilities for parsing LFS documentation files."""
 
 from __future__ import annotations

--- a/src/parsers/package_analyzer.py
+++ b/src/parsers/package_analyzer.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 The LFS Automation Team
+
 """Helpers for analyzing package build instructions."""
 
 from __future__ import annotations

--- a/src/parsers/regenerate_all_scripts.sh
+++ b/src/parsers/regenerate_all_scripts.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 The LFS Automation Team
+
 # Regenerate all build scripts by parsing documentation
 set -euo pipefail
 

--- a/src/validators/dependency_checker.sh
+++ b/src/validators/dependency_checker.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 The LFS Automation Team
+
 # Dependency Checker: Validate build dependencies
 set -euo pipefail
 

--- a/src/validators/package_tester.sh
+++ b/src/validators/package_tester.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 The LFS Automation Team
+
 # Package Tester: Test individual packages
 set -euo pipefail
 

--- a/src/validators/system_validator.sh
+++ b/src/validators/system_validator.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 The LFS Automation Team
+
 # System Validator: Validate complete system
 set -euo pipefail
 


### PR DESCRIPTION
## Summary
- add a short MIT license notice to each script in `src/` and `generated/`

## Testing
- `bash tests/run_tests.sh`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'bs4')*

------
https://chatgpt.com/codex/tasks/task_e_68713dc085d08332aba08a444a59a49b