### PR TITLE
Add package analyzer tests and bs4 fallback

### DIFF
--- a/tests/test_package_analyzer.py
+++ b/tests/test_package_analyzer.py
@@ -1,0 +1,19 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'src'))
+
+from parsers import package_analyzer
+
+
+def test_analyze_bash():
+    data = package_analyzer.analyze_package('bash')
+    assert data, 'analyze_package returned empty data'
+    assert data['commands'], 'commands list is empty'
+    assert 'Glibc' in data['dependencies']
+
+
+def test_analyze_coreutils():
+    data = package_analyzer.analyze_package('coreutils')
+    assert data['commands'], 'commands list is empty for coreutils'
+    assert 'Patch' in data['dependencies']


### PR DESCRIPTION
## Summary
- add unit tests for `package_analyzer.analyze_package`
- make `lfs_parser` and `dependency_resolver` work without BeautifulSoup so tests run in minimal environments

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68713dab1ed88332a5e08ee7dbb68fa4