### PR TITLE
Add stub complete build script

### DIFF
--- a/generated/complete_build.sh
+++ b/generated/complete_build.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Auto-LFS-Builder Master Build Script
+# Generated stub orchestrator for full system build
+set -euo pipefail
+
+log_phase() { echo "=== $1 ==="; }
+
+log_phase "Starting LFS build"
+# Placeholder for LFS build steps
+
+log_phase "Configuring networking"
+# Placeholder for networking setup
+
+log_phase "Installing GNOME desktop"
+# Placeholder for GNOME installation
+
+log_phase "Applying BLFS packages"
+# Placeholder for BLFS extras
+
+log_phase "Build process complete"


### PR DESCRIPTION
## Summary
- add stub `generated/complete_build.sh` to orchestrate build phases

## Testing
- `bash generated/validation_suite.sh`
- `bash tests/run_tests.sh`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'bs4')*

------
https://chatgpt.com/codex/tasks/task_e_68713dbe7e3c8332aefd19f83d8371cc