### PR TITLE
Make helper sourcing path independent

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,4 +12,9 @@ Gaming on Linux from Scratch
 
 
 All in one application.
+
+Each builder, installer, and validator script now determines its own
+location when sourcing helper files. This means you can execute any of
+these scripts from any directory and they will locate their required
+helpers correctly.
 See [SETUP.md](SETUP.md) for environment configuration details.

--- a/src/builders/blfs_builder.sh
+++ b/src/builders/blfs_builder.sh
@@ -2,9 +2,10 @@
 # BLFS Builder: Install additional BLFS packages
 set -euo pipefail
 
-source src/common/logging.sh
-source src/common/error_handling.sh
-source src/common/package_management.sh
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/../common/logging.sh"
+source "${SCRIPT_DIR}/../common/error_handling.sh"
+source "${SCRIPT_DIR}/../common/package_management.sh"
 
 install_blfs_packages() {
     # Install additional desktop and networking packages

--- a/src/builders/gnome_builder.sh
+++ b/src/builders/gnome_builder.sh
@@ -2,9 +2,10 @@
 # GNOME Builder: Install GNOME desktop environment
 set -euo pipefail
 
-source src/common/logging.sh
-source src/common/error_handling.sh
-source src/common/package_management.sh
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/../common/logging.sh"
+source "${SCRIPT_DIR}/../common/error_handling.sh"
+source "${SCRIPT_DIR}/../common/package_management.sh"
 
 install_graphics_stack() {
     # Mesa, graphics drivers, Wayland/X11

--- a/src/builders/lfs_builder.sh
+++ b/src/builders/lfs_builder.sh
@@ -2,9 +2,10 @@
 # LFS Builder: Core LFS build automation
 set -euo pipefail
 
-source src/common/logging.sh
-source src/common/error_handling.sh
-source src/common/package_management.sh
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/../common/logging.sh"
+source "${SCRIPT_DIR}/../common/error_handling.sh"
+source "${SCRIPT_DIR}/../common/package_management.sh"
 
 build_toolchain() {
     # Placeholder for toolchain build steps

--- a/src/builders/master_builder.sh
+++ b/src/builders/master_builder.sh
@@ -2,16 +2,17 @@
 # Master Builder: Orchestrates complete system build
 set -euo pipefail
 
-source src/common/logging.sh
-source src/common/error_handling.sh
-source src/common/package_management.sh
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/../common/logging.sh"
+source "${SCRIPT_DIR}/../common/error_handling.sh"
+source "${SCRIPT_DIR}/../common/package_management.sh"
 
 main() {
     log_info "Starting master build process"
-    bash src/builders/lfs_builder.sh
-    bash src/builders/networking_builder.sh
-    bash src/builders/gnome_builder.sh
-    bash src/builders/blfs_builder.sh
+    bash "${SCRIPT_DIR}/lfs_builder.sh"
+    bash "${SCRIPT_DIR}/networking_builder.sh"
+    bash "${SCRIPT_DIR}/gnome_builder.sh"
+    bash "${SCRIPT_DIR}/blfs_builder.sh"
     log_success "Master build completed successfully"
 }
 

--- a/src/builders/networking_builder.sh
+++ b/src/builders/networking_builder.sh
@@ -2,9 +2,10 @@
 # Networking Builder: Configure network stack
 set -euo pipefail
 
-source src/common/logging.sh
-source src/common/error_handling.sh
-source src/common/package_management.sh
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/../common/logging.sh"
+source "${SCRIPT_DIR}/../common/error_handling.sh"
+source "${SCRIPT_DIR}/../common/package_management.sh"
 
 install_network_stack() {
     # NetworkManager, wireless tools, firewall

--- a/src/installers/bootstrap_installer.sh
+++ b/src/installers/bootstrap_installer.sh
@@ -2,9 +2,10 @@
 # Bootstrap Installer: Hardware detection and installation
 set -euo pipefail
 
-source src/common/logging.sh
-source src/common/error_handling.sh
-source src/common/package_management.sh
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/../common/logging.sh"
+source "${SCRIPT_DIR}/../common/error_handling.sh"
+source "${SCRIPT_DIR}/../common/package_management.sh"
 
 run_installer() {
     # Placeholder for bootstrap installation routine

--- a/src/installers/iso_creator.sh
+++ b/src/installers/iso_creator.sh
@@ -2,9 +2,10 @@
 # ISO Creator: Generate bootable ISO image
 set -euo pipefail
 
-source src/common/logging.sh
-source src/common/error_handling.sh
-source src/common/package_management.sh
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/../common/logging.sh"
+source "${SCRIPT_DIR}/../common/error_handling.sh"
+source "${SCRIPT_DIR}/../common/package_management.sh"
 
 create_iso_image() {
     # Placeholder for ISO generation logic

--- a/src/installers/partition_manager.sh
+++ b/src/installers/partition_manager.sh
@@ -2,9 +2,10 @@
 # Partition Manager: Automatic disk partitioning
 set -euo pipefail
 
-source src/common/logging.sh
-source src/common/error_handling.sh
-source src/common/package_management.sh
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/../common/logging.sh"
+source "${SCRIPT_DIR}/../common/error_handling.sh"
+source "${SCRIPT_DIR}/../common/package_management.sh"
 
 create_partitions() {
     # Placeholder for disk partitioning logic

--- a/src/validators/dependency_checker.sh
+++ b/src/validators/dependency_checker.sh
@@ -2,9 +2,10 @@
 # Dependency Checker: Validate build dependencies
 set -euo pipefail
 
-source src/common/logging.sh
-source src/common/error_handling.sh
-source src/common/package_management.sh
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/../common/logging.sh"
+source "${SCRIPT_DIR}/../common/error_handling.sh"
+source "${SCRIPT_DIR}/../common/package_management.sh"
 
 check_dependencies() {
     # Placeholder for dependency checking logic

--- a/src/validators/package_tester.sh
+++ b/src/validators/package_tester.sh
@@ -2,9 +2,10 @@
 # Package Tester: Test individual packages
 set -euo pipefail
 
-source src/common/logging.sh
-source src/common/error_handling.sh
-source src/common/package_management.sh
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/../common/logging.sh"
+source "${SCRIPT_DIR}/../common/error_handling.sh"
+source "${SCRIPT_DIR}/../common/package_management.sh"
 
 test_package() {
     # Placeholder for package testing logic

--- a/src/validators/system_validator.sh
+++ b/src/validators/system_validator.sh
@@ -2,9 +2,10 @@
 # System Validator: Validate complete system
 set -euo pipefail
 
-source src/common/logging.sh
-source src/common/error_handling.sh
-source src/common/package_management.sh
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/../common/logging.sh"
+source "${SCRIPT_DIR}/../common/error_handling.sh"
+source "${SCRIPT_DIR}/../common/package_management.sh"
 
 validate_system() {
     # Placeholder for system validation logic


### PR DESCRIPTION
## Summary
- source common helpers based on each script's own location
- allow master builder to launch sub-builders relative to itself
- document that all scripts can run from any directory

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68713db788dc8332a48ae6b815030d9f