### PR TITLE
Update CI to use pipeline script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install beautifulsoup4 lxml requests pytest
-      - name: Run validation suite
-        run: ENABLE_GNOME=false bash generated/validation_suite.sh
+      - name: Run CI pipeline
+        run: bash scripts/ci_pipeline.sh
       - name: Run unit tests
         run: bash tests/run_tests.sh

--- a/scripts/ci_pipeline.sh
+++ b/scripts/ci_pipeline.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -euo pipefail
+
+# CI/CD Testing Environment variables from SETUP.md
+export LFS="/tmp/lfs-ci-build"
+export BUILD_PROFILE="minimal"
+export PARALLEL_JOBS="2"
+export PARSING_LOG_LEVEL="DEBUG"
+export VALIDATION_MODE="permissive"
+export ENABLE_GNOME="false"
+export ENABLE_NETWORKING="true"
+export VERIFY_PACKAGES="false"
+export CHECKSUM_VALIDATION="sha256"
+
+bash generated/validation_suite.sh


### PR DESCRIPTION
## Summary
- add `scripts/ci_pipeline.sh` for CI/CD pipeline
- call the new pipeline from the GitHub Actions workflow
- keep unit tests as a separate job step

## Testing
- `bash tests/run_tests.sh`
- `bash scripts/ci_pipeline.sh`

------
https://chatgpt.com/codex/tasks/task_e_68768d4a36688332a53bb5e25b983706