### PR TITLE
Add validation scripts

### DIFF
--- a/src/validators/dependency_checker.sh
+++ b/src/validators/dependency_checker.sh
@@ -8,10 +8,13 @@ set -euo pipefail
 source src/common/logging.sh
 source src/common/error_handling.sh
 source src/common/package_management.sh
+source generated/validation_suite.sh
 
 check_dependencies() {
-    # Placeholder for dependency checking logic
-    :
+    local deps=(wget tar gcc make)
+    for bin in "${deps[@]}"; do
+        check_binary_exists "$bin" "$bin not found" || return 1
+    done
 }
 
 main() {

--- a/src/validators/package_tester.sh
+++ b/src/validators/package_tester.sh
@@ -8,10 +8,20 @@ set -euo pipefail
 source src/common/logging.sh
 source src/common/error_handling.sh
 source src/common/package_management.sh
+source generated/validation_suite.sh
 
 test_package() {
-    # Placeholder for package testing logic
-    :
+    local pkg="${1:-}"
+    if [ -z "$pkg" ]; then
+        log_error "No package specified"
+        return 1
+    fi
+
+    check_binary_exists "$pkg" "$pkg not installed" || return 1
+    "$pkg" --version >/dev/null 2>&1 || {
+        log_error "$pkg failed to run"
+        return 1
+    }
 }
 
 main() {

--- a/src/validators/system_validator.sh
+++ b/src/validators/system_validator.sh
@@ -8,10 +8,13 @@ set -euo pipefail
 source src/common/logging.sh
 source src/common/error_handling.sh
 source src/common/package_management.sh
+source generated/validation_suite.sh
 
 validate_system() {
-    # Placeholder for system validation logic
-    :
+    validate_lfs_system || return 1
+    if [ "${ENABLE_GNOME:-false}" = "true" ]; then
+        validate_gnome_desktop || return 1
+    fi
 }
 
 main() {

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1,0 +1,31 @@
+import os
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def run_script(path, *args, env=None):
+    env_dict = os.environ.copy()
+    if env:
+        env_dict.update(env)
+    result = subprocess.run([
+        str(ROOT / path), *args
+    ], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, cwd=ROOT, env=env_dict)
+    assert result.returncode == 0, result.stdout
+    return result.stdout
+
+
+def test_dependency_checker_runs():
+    out = run_script('src/validators/dependency_checker.sh')
+    assert 'Dependency check complete' in out
+
+
+def test_package_tester_runs():
+    out = run_script('src/validators/package_tester.sh', 'bash')
+    assert 'Package testing complete' in out
+
+
+def test_system_validator_runs():
+    out = run_script('src/validators/system_validator.sh', env={'ENABLE_GNOME': 'false'})
+    assert 'System validation complete' in out


### PR DESCRIPTION
## Summary
- implement actual checks in validator scripts
- rely on routines from `generated/validation_suite.sh`
- add tests for new validator scripts

## Testing
- `tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68768d4cd9288332bd0a7bc31520e015