### PR TITLE
Fix cleanup status logging

### DIFF
--- a/lfs-build.sh
+++ b/lfs-build.sh
@@ -101,11 +101,17 @@ log_phase() {
 
 # Error handling
 cleanup() {
-    log_error "Build interrupted or failed"
-    log_info "Cleaning up..."
-    # Add cleanup logic here
+    local status=$1
+    trap - ERR EXIT
+    if [[ $status -ne 0 ]]; then
+        log_error "Build interrupted or failed (status: $status)"
+        log_info "Cleaning up..."
+        # Add cleanup logic here
+    else
+        log_success "Build completed successfully"
+    fi
 }
-trap cleanup EXIT
+trap 'cleanup $?' ERR EXIT
 
 # Validate environment
 validate_environment() {


### PR DESCRIPTION
## Summary
- detect exit status in `cleanup`
- emit success when status is 0
- set traps to run `cleanup` for `ERR` and `EXIT`

## Testing
- `bash tests/run_tests.sh` *(fails: validation fails due to environment)*

------
https://chatgpt.com/codex/tasks/task_e_687753b9dbc4833299b33258ff4a40a2