### PR TITLE
Fix cleanup exit messages

### DIFF
--- a/lfs-build-fixed.sh
+++ b/lfs-build-fixed.sh
@@ -121,12 +121,17 @@ log_phase() {
 # Improved error handling to prevent loops
 CLEANUP_CALLED=false
 cleanup() {
+    local status=$?
     if [[ "$CLEANUP_CALLED" == "true" ]]; then
         return 0  # Prevent recursive cleanup calls
     fi
     CLEANUP_CALLED=true
-    
-    log_error "Build interrupted or failed"
+
+    if [[ $status -ne 0 ]]; then
+        log_error "Build interrupted or failed (exit code $status)"
+    else
+        log_success "Build completed successfully"
+    fi
     log_info "Cleaning up..."
     
     # Show current location and status
@@ -143,7 +148,7 @@ cleanup() {
 }
 
 # Set trap but disable exit on error temporarily for better control
-trap cleanup ERR
+trap cleanup ERR EXIT
 
 # Validate environment
 validate_environment() {

--- a/lfs-build.sh
+++ b/lfs-build.sh
@@ -100,12 +100,22 @@ log_phase() {
 }
 
 # Error handling
+CLEANUP_CALLED=false
 cleanup() {
-    log_error "Build interrupted or failed"
+    local status=$?
+    if [[ "$CLEANUP_CALLED" == "true" ]]; then
+        return 0
+    fi
+    CLEANUP_CALLED=true
+    if [[ $status -ne 0 ]]; then
+        log_error "Build interrupted or failed (exit code $status)"
+    else
+        log_success "Build completed successfully"
+    fi
     log_info "Cleaning up..."
     # Add cleanup logic here
 }
-trap cleanup EXIT
+trap cleanup ERR EXIT
 
 # Validate environment
 validate_environment() {


### PR DESCRIPTION
## Summary
- improve cleanup logic
- make cleanup report success or failure based on exit code
- hook cleanup with `ERR` and `EXIT` traps

## Testing
- `python -m pytest -q tests` *(fails: dependency_checker, package_tester, system_validator)*

------
https://chatgpt.com/codex/tasks/task_e_687753c33ab883328ceb236bd06a1caa