### PR TITLE
Fix log_phase usage in complete_build.sh

### DIFF
--- a/generated/complete_build.sh
+++ b/generated/complete_build.sh
@@ -6,6 +6,19 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 MAIN_SCRIPT="$SCRIPT_DIR/../lfs-build.sh"
 
+# Try to source common logging utilities if available
+if [[ -f "$SCRIPT_DIR/../src/common/logging.sh" ]]; then
+    # shellcheck source=../src/common/logging.sh
+    source "$SCRIPT_DIR/../src/common/logging.sh"
+fi
+
+# Provide a very small log_phase helper if none was loaded
+if ! declare -f log_phase >/dev/null 2>&1; then
+    log_phase() {
+        echo -e "\n[PHASE] $*\n"
+    }
+fi
+
 log_phase "Starting LFS build"
 # Placeholder for LFS build steps
 


### PR DESCRIPTION
## Summary
- ensure log_phase function is available in `generated/complete_build.sh`

## Testing
- `bash tests/run_tests.sh` *(fails: Validation failed with error(s))*

------
https://chatgpt.com/codex/tasks/task_e_68787f34ee148332adc2b00235c8a68e