### PR TITLE
Fix kernel detection in iso creator

### DIFF
--- a/iso-creator.sh
+++ b/iso-creator.sh
@@ -37,7 +37,7 @@ create_iso_image() {
     fi
     
     # Check if we have a kernel
-    if [[ ! -f "$build_root/boot/vmlinuz"* ]]; then
+    if ! compgen -G "$build_root/boot/vmlinuz*" > /dev/null; then
         log_warning "No kernel found in $build_root/boot/"
         log_info "Creating minimal boot structure"
         mkdir -p "$build_root/boot"


### PR DESCRIPTION
## Summary
- improve detection of the built kernel in `iso-creator.sh`

## Testing
- `bash tests/run_tests.sh` *(fails: Validation failed with 1 error)*

------
https://chatgpt.com/codex/tasks/task_e_687884f030d88332879772cac0360afe