### PR TITLE
Align scripts with docker LFS mount

### DIFF
--- a/lfs-build-fixed.sh
+++ b/lfs-build-fixed.sh
@@ -18,7 +18,7 @@ if [[ -f "$(dirname "$0")/lfs-builder.env" ]]; then
 fi
 
 # Set up logging
-LOG_PATH=/mnt/lfs/logs/build.log
+LOG_PATH="${LOG_PATH:-/lfs-build/logs/build.log}"
 LOG_DIR=$(dirname "$LOG_PATH")
 mkdir -p "$LOG_DIR"
 
@@ -206,7 +206,7 @@ setup_lfs_environment() {
     log_phase "Setting up LFS Environment"
     
     # Create LFS directories
-    export LFS="$LFS_WORKSPACE/lfs"
+    export LFS="${LFS:-/mnt/lfs}"
     mkdir -p "$LFS"
     mkdir -p "$LFS"/{etc,var,usr,tools,home,mnt,proc,sys,dev}
     mkdir -p "$LFS/usr"/{bin,lib,sbin}

--- a/lfs-build-glibc-fixed.sh
+++ b/lfs-build-glibc-fixed.sh
@@ -18,7 +18,7 @@ if [[ -f "$(dirname "$0")/lfs-builder.env" ]]; then
 fi
 
 # Set up logging
-LOG_PATH=/mnt/lfs/logs/build.log
+LOG_PATH="${LOG_PATH:-/lfs-build/logs/build.log}"
 LOG_DIR=$(dirname "$LOG_PATH")
 mkdir -p "$LOG_DIR"
 
@@ -160,7 +160,7 @@ setup_lfs_environment() {
     log_phase "Setting up LFS Environment"
     
     # Create LFS directories
-    export LFS="$LFS_WORKSPACE/lfs"
+    export LFS="${LFS:-/mnt/lfs}"
     mkdir -p "$LFS"
     mkdir -p "$LFS"/{etc,var,usr,tools,home,mnt,proc,sys,dev}
     mkdir -p "$LFS/usr"/{bin,lib,sbin}

--- a/lfs-build.sh
+++ b/lfs-build.sh
@@ -18,7 +18,7 @@ if [[ -f "$(dirname "$0")/lfs-builder.env" ]]; then
 fi
 
 # Set up logging
-LOG_PATH=/mnt/lfs/logs/build.log
+LOG_PATH="${LOG_PATH:-/lfs-build/logs/build.log}"
 LOG_DIR=$(dirname "$LOG_PATH")
 mkdir -p "$LOG_DIR"
 
@@ -162,7 +162,7 @@ setup_lfs_environment() {
     log_phase "Setting up LFS Environment"
     
     # Create LFS directories
-    export LFS="$LFS_WORKSPACE/lfs"
+    export LFS="${LFS:-/mnt/lfs}"
     mkdir -p "$LFS"
     mkdir -p "$LFS"/{etc,var,usr,tools,home,mnt,proc,sys,dev}
     mkdir -p "$LFS/usr"/{bin,lib,sbin}


### PR DESCRIPTION
## Summary
- use LOG_PATH environment variable in build scripts
- default LFS variable to `/mnt/lfs`
- ensure env file uses `/lfs-build/logs/build.log`

## Testing
- `bash tests/run_tests.sh` *(fails: Validation failed with 1 error)*

------
https://chatgpt.com/codex/tasks/task_e_687884eed61c8332a57730b19b2f918f