### PR TITLE
docs: document jhalfs usage

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -212,6 +212,22 @@ After successful build:
 - **workspace/**: Build artifacts
 - **logs/**: Build logs
 
+## Running jhalfs Inside the Container
+
+The `docs/jhalfs/` directory ships the upstream **jhalfs** automation
+tool. It may be launched from the container using `docker compose run`.
+Use the same bind mounts as the normal builder so that jhalfs writes to
+your host directories: `lfs-mount` -> `/mnt/lfs`, `workspace/` ->
+`/lfs-build/workspace`, and `logs/` -> `/lfs-build/logs`.
+
+```bash
+# Start the interactive jhalfs menu
+docker compose run lfs-builder ./docs/jhalfs/jhalfs
+```
+
+Refer to `docs/jhalfs/README` and the other READMEs in that directory
+for configuration details and advanced usage.
+
 ## Next Steps
 
 1. **Create Boot Media**

--- a/README.md
+++ b/README.md
@@ -97,6 +97,26 @@ The build process follows these steps:
 - **server**: Networking, no GUI
 - **developer**: Development tools
 
+## 🧰 Running jhalfs in Docker
+
+The project includes the [jhalfs](docs/jhalfs/README) automation
+tool. It can be executed inside the container to generate an LFS
+Makefile and run the build interactively. Mount the same directories as
+the normal builder service so jhalfs can access your host volumes:
+`lfs-mount` -> `/mnt/lfs`, `workspace/` -> `/lfs-build/workspace`, and
+`logs/` -> `/lfs-build/logs`.
+
+```bash
+# Launch the jhalfs menu
+docker compose run lfs-builder ./docs/jhalfs/jhalfs
+
+# Run with additional options
+docker compose run lfs-builder ./docs/jhalfs/jhalfs -d /mnt/lfs
+```
+
+For configuration details see `docs/jhalfs/README`,
+`docs/jhalfs/README.BLFS` and related files.
+
 ## 📝 Output Files
 
 After building, you'll find:


### PR DESCRIPTION
## Summary
- add section on running jhalfs inside Docker to README
- include jhalfs instructions in DOCKER.md

## Testing
- `bash tests/run_tests.sh` *(fails: Validation failed with missing packages)*

------
https://chatgpt.com/codex/tasks/task_e_687888b4e16883328ee67ac0eceda55d