### PR TITLE
Add mock jhalfs test

### DIFF
--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -14,8 +14,9 @@ if [[ ! -f generated/validation_suite.sh ]]; then
     cp scripts/templates/validation_suite.sh.template generated/validation_suite.sh
 fi
 
-# Source validation suite
-source generated/validation_suite.sh
+# Source validation suite functions without running main
+# Strip the final invocation to allow sourcing in CI environments
+source <(grep -v 'main \"\$@\"' generated/validation_suite.sh)
 
 check_binary_exists bash "bash missing"
 if check_binary_exists nonexistent_binary "should fail"; then

--- a/tests/test_jhalfs_run.py
+++ b/tests/test_jhalfs_run.py
@@ -1,0 +1,33 @@
+import subprocess
+from pathlib import Path
+import textwrap
+
+
+def test_mock_jhalfs_run(tmp_path: Path) -> None:
+    """Run a mocked jhalfs script and verify generated files."""
+    script = tmp_path / "jhalfs"
+    script.write_text(
+        textwrap.dedent(
+            """
+            #!/bin/bash
+            set -e
+            outdir=$1
+            mkdir -p "$outdir/scripts"
+            touch "$outdir/scripts/Makefile"
+            echo "Mock jhalfs completed"
+            """
+        )
+    )
+    script.chmod(0o755)
+
+    workdir = tmp_path / "work"
+    result = subprocess.run(
+        [str(script), str(workdir)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert "Mock jhalfs completed" in result.stdout
+    assert (workdir / "scripts" / "Makefile").is_file()


### PR DESCRIPTION
## Summary
- add a mock jhalfs dry-run test
- load validation helpers without executing the full validation suite

## Testing
- `bash tests/run_tests.sh` *(fails: Validation failed)*

------
https://chatgpt.com/codex/tasks/task_e_687888b27bfc833284e512795b397d09